### PR TITLE
Add Jest setup and basic Navigation test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Run tests
+        run: yarn test

--- a/__mocks__/file-mock.js
+++ b/__mocks__/file-mock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'jsdom',
+  testEnvironment: 'jest-environment-jsdom',
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,5 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/file-mock.js',
   },
   transformIgnorePatterns: ['node_modules/(?!(gatsby)/)'],
-  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
+    '^@/images/(.*)$': '<rootDir>/__mocks__/file-mock.js',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^~/(.*)$': '<rootDir>/$1',
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,12 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^~/(.*)$': '<rootDir>/$1',
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    '\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/file-mock.js',
+  },
+  transformIgnorePatterns: ['node_modules/(?!(gatsby)/)'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,5 +9,8 @@ module.exports = {
     '\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/file-mock.js',
   },
   transformIgnorePatterns: ['node_modules/(?!(gatsby)/)'],
-  setupFilesAfterEnv: ['@testing-library/jest-dom'],
+  setupFilesAfterEnv: [
+    '@testing-library/jest-dom',
+    '<rootDir>/jest.setup.js',
+  ],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,13 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "@testing-library/react": "^14.1.2",
     "@types/jest": "^29.5.3",
     "jest": "^29.7.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "jest-environment-jsdom": "^29.7.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby-starter-blog#readme",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,12 @@
     "eslint-config-typescript": "^3.0.0",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "@testing-library/jest-dom": "^6.1.6",
+    "@testing-library/react": "^14.1.2",
+    "@types/jest": "^29.5.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby-starter-blog#readme",
   "keywords": [
@@ -68,6 +73,6 @@
     "clean": "gatsby clean",
     "generate": "graphql-codegen --config codegen.yml",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
+    "test": "jest"
   }
 }

--- a/src/components/__tests__/navigation.test.tsx
+++ b/src/components/__tests__/navigation.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Navigation from '../navigation';
+
+describe('Navigation', () => {
+  it('renders About link', () => {
+    render(<Navigation />);
+    const aboutLink = screen.getByRole('link', { name: /about/i });
+    expect(aboutLink).toBeInTheDocument();
+  });
+});

--- a/src/components/navigation.test.tsx
+++ b/src/components/navigation.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import Navigation from '../navigation';
+import Navigation from './navigation';
 
 describe('Navigation', () => {
   it('renders About link', () => {


### PR DESCRIPTION
## Summary
- install Jest and React Testing Library
- configure Jest for ts-jest
- create a sample navigation test
- update the npm test script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d052160848329a1f5beba97f2460b